### PR TITLE
Add `isEC2` method to check whether the host is on EC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ Q.all([
 });
 ```
 
+The ```isEC2``` method detects whether the code is running on EC2. It returns a promise, where the result will be a boolean. The initial call may take up to 500ms on a non-EC2 host, but the result is cached so subsequent calls provide a result immediately.
+
+```javascript
+var metadata = require('node-ec2-metadata');
+
+metadata.isEC2()
+.then(function(onEC2) {
+    console.log("Running on EC2? " + onEC2);
+});
+```
+
+
 ## License
 
 The MIT License (MIT)

--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,13 @@
 var metadata = require('node-ec2-metadata');
 var Q = require('q');
 
+// Check whether we're running on EC2
+metadata.isEC2()
+.then(function (result) {
+    console.log("On EC2?", result);
+})
+
+// Get a set of properties
 Q.all([
     metadata.getMetadataForInstance('ami-id'),
     metadata.getMetadataForInstance('hostname'),

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,9 @@
  */
 var Q = require('q');
 var _ = require('lodash');
+var dns = require('dns');
 var http = require('http');
+var url = require('url');
 
 /*
     Endpoint Configuration
@@ -201,6 +203,41 @@ var getMetadataForInstance = function(type, args) {
     return fetchDataForURL(url);
 };
 
+var isEC2 = function() {
+    // the host running the process won't change, so we can cache this value
+    if (isEC2._cached !== undefined) {
+        return Q(isEC2._cached);
+    }
+
+    var deferred = Q.defer();
+    var promise = deferred.promise.then(function setCache(value) {
+        isEC2._cached = value;
+        return value;
+    });
+
+    // first try to resolve ec2 internal metadata. This doesn't work with VPC or custom DNS though.
+    dns.lookup('instance-data.ec2.internal.', function dnsResult(err, result) {
+        if (result == '169.254.169.254') {
+            deferred.resolve(true);
+        } else {
+            // next do a HEAD query to 'http://169.254.169.254/latest/' with a short timeout
+            var reqOpts = _.assign(url.parse(BASE_URL), {method: 'HEAD'});
+            var req = http.request(reqOpts, function httpRes(res) {
+                deferred.resolve(true);
+                req.abort();
+            });
+            req.setTimeout( 500, function httpTimeout() {
+                deferred.resolve(false);
+            });
+            req.on('error', function httpErr(e) {
+                deferred.resolve(false);
+            });
+            req.end();
+        }
+    });
+    return promise;
+}
+
 /*
     EXPORTS
  */
@@ -208,3 +245,4 @@ var getMetadataForInstance = function(type, args) {
 exports.urlForType = urlForType;
 exports.replaceValuesForType = replaceValuesForType;
 exports.getMetadataForInstance = getMetadataForInstance;
+exports.isEC2 = isEC2;


### PR DESCRIPTION
Pretty self-descriptive. Tries to do a DNS lookup of `instance-data.ec2.internal.` first (which works on non-VPC instances), then falls back to a HEAD request to `http://169.254.169.254/latest` with a short timeout. The value is cached for subsequent calls.

Example usage:

``` javascript
var metadata = require('node-ec2-metadata');

metadata.isEC2()
.then(function(onEC2) {
    console.log("Running on EC2? " + onEC2);
});
```
