### PR TITLE
Handle non-200 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install node-ec2-metadata
 
 ## API
 
-This module exposes a method ```getMetadataForInstance``` which returns a promise.  You can see an example below for fetching the instance ID of a running EC2 instance.  To see the data types that you can call, review <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html">Instance Metadata and User Data</a>.
+This module exposes a method ```getMetadataForInstance``` which returns a promise.  You can see an example below for fetching the instance ID of a running EC2 instance.  To see the data types that you can call, review <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html">Instance Metadata and User Data</a>. Metadata that doesn't apply to an instance will return `null` values.
 
 ```javascript
 var metadata = require('node-ec2-metadata');

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,17 @@ var fetchDataForURL = function(url) {
             result += chunk;
         });
         res.on('end', function() {
-            deferred.resolve(result);
+            if (res.statusCode >= 200 && res.statusCode < 300) {
+                deferred.resolve(result);
+            } else if (res.statusCode == 404) {
+                // return null for 404 responses - we already know it's a valid request
+                // eg. public-ipv4 of a VPC instance without one
+                deferred.resolve(null);
+            } else {
+                var e = new Error(result);
+                e.code = res.statusCode;
+                deferred.reject(e);
+            }
         });
     });
     req.setTimeout( 2500, function() {


### PR DESCRIPTION
This deals with metadata that doesn't apply to a specific instance (eg. `public-ipv4` of a VPC host without one). In these cases (when the HTTP request returns a 404), return it as a `null` result.

Turns other non-2xx responses into errors rather than returning them to the deferred as a result.
