### PR TITLE
Allow dynamic types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,7 @@ var replaceValuesForType = function(type, args) {
 };
 
 var getMetadataForInstance = function(type, args) {
-    if(_.indexOf(ALLOWED_METADATA_VALUES,type) < 0) {
+    if(_.indexOf(ALLOWED_TYPES,type) < 0) {
         var deferred = Q.defer();
         deferred.reject("Not a valid metadata type");
         return deferred.promise;

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,6 +160,7 @@ var fetchDataForURL = function(url) {
     });
     req.setTimeout( 2500, function() {
         deferred.reject(new Error('EC2-Metadata Fetch Timeout.'));
+        req.abort();
     });
     req.on('error', function(e) {
         deferred.reject(e);
@@ -242,7 +243,6 @@ var isEC2 = function() {
             });
             req.on('error', function httpErr(e) {
                 deferred.resolve(false);
-                req.abort();
             });
             req.end();
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /*
 
     This module is designed to wrap the EC2 metadata gathering process.  AWS provides
-    an endpoint that you can hit to get specific metadata values.  
+    an endpoint that you can hit to get specific metadata values.
 
     You can see the AWS metadata documentation here:
     http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
@@ -69,7 +69,7 @@ var ALLOWED_METADATA_VALUES = [
 ];
 
 /*
-    All allowed data types 
+    All allowed data types
  */
 var ALLOWED_TYPES = _.union(ALLOWED_METADATA_VALUES, ALLOWED_DYNAMIC_VALUES);
 
@@ -182,7 +182,7 @@ var urlForType = function(type, args) {
 
     return url;
 };
- 
+
 var replaceValuesForType = function(type, args) {
     if(REPLACEMENT_STRINGS.hasOwnProperty(type)) {
         var requiredArgCount = REQUIRED_ARGUMENT_COUNT[type] || 0;
@@ -207,7 +207,7 @@ var getMetadataForInstance = function(type, args) {
         var deferred = Q.defer();
         deferred.reject("Not a valid metadata type");
         return deferred.promise;
-    } 
+    }
 
     var url = urlForType(type, args);
     return fetchDataForURL(url);
@@ -238,9 +238,11 @@ var isEC2 = function() {
             });
             req.setTimeout( 500, function httpTimeout() {
                 deferred.resolve(false);
+                req.abort();
             });
             req.on('error', function httpErr(e) {
                 deferred.resolve(false);
+                req.abort();
             });
             req.end();
         }


### PR DESCRIPTION
getMetadataForInstance only allows queries to the meta-data endpoint, even though this package defines dynamic endpoints. Updated getMetadataForInstance to allow dynamic endpoint queries.
