### PR TITLE
Fix timeout not working in Node v10.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ build/Release
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
 test-reports
+
+.vscode

--- a/example/package.json
+++ b/example/package.json
@@ -3,14 +3,14 @@
   "preferGlobal": false,
   "version": "0.0.1",
   "author": "David Tucker <david.tucker@universalmind.com>",
-  "description" : "Example for fetching AWS EC2 metadata for an instance",
+  "description": "Example for fetching AWS EC2 metadata for an instance",
   "license": "MIT",
   "main": "index.js",
   "engines": {
     "node": ">=0.10"
   },
   "dependencies": {
-    "node-ec2-metadata" : "~0.0.2",
+    "node-ec2-metadata": "~0.0.7",
     "q": "~1.0.1"
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,7 @@ var isAllowedType = function(type) {
 
 var fetchDataForURL = function(url) {
     var deferred = Q.defer();
-    var req = http.get(url, function(res) {
+    var req = http.get(url, {timeout: 2500}, function(res) {
         res.setEncoding('utf8');
         var result = "";
         res.on('data', function(chunk) {
@@ -158,7 +158,7 @@ var fetchDataForURL = function(url) {
             }
         });
     });
-    req.setTimeout( 2500, function() {
+    req.on('timeout', function() {
         deferred.reject(new Error('EC2-Metadata Fetch Timeout.'));
         req.abort();
     });
@@ -230,12 +230,12 @@ var isEC2 = function() {
             deferred.resolve(true);
         } else {
             // next do a HEAD query to 'http://169.254.169.254/latest/' with a short timeout
-            var reqOpts = _.assign(url.parse(BASE_URL), {method: 'HEAD'});
+            var reqOpts = _.assign(url.parse(BASE_URL), {method: 'HEAD', timeout: 500});
             var req = http.request(reqOpts, function httpRes(res) {
                 deferred.resolve(true);
                 req.abort();
             });
-            req.setTimeout( 500, function httpTimeout() {
+            req.on('timeout', function httpTimeout() {
                 deferred.resolve(false);
                 req.abort();
             });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-ec2-metadata",
   "preferGlobal": false,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "David Tucker <david.tucker@universalmind.com>",
   "description": "Module for fetching AWS EC2 metadata for an instance",
   "license": "MIT",


### PR DESCRIPTION
http.request timeouts were not working in node v10.13.0. Changed to set timeout as part of initial http.request to fix.  

Please publish to npmjs.com also when you accept the pull request.

Thanks!